### PR TITLE
Update to the latest travis_setup.sh for Scala Native

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,6 @@ matrix:
     scala: 2.11.12
     dist: trusty
     before_install:
-    - curl https://raw.githubusercontent.com/scala-native/scala-native/0f69c875d2cb2/bin/travis_setup.sh | bash -x
+    - curl https://raw.githubusercontent.com/scala-native/scala-native/master/scripts/travis_setup.sh | bash -x
     script:
     - sbt protobufRuntimeScalaNative/test "show protobufRuntimeScalaNative/nativeMissingDependencies"


### PR DESCRIPTION
[Recent PR](https://github.com/scala-native/scala-native/pull/1195) changed the location of the travis setup script within a Scala Native repo. This PR updates travis build to point to the new location.