### PR TITLE
Support Scala Native 0.4.0 and Scala.js 1.4.0, drop 2.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        scala: [2.11.7, 2.12.10, 2.13.1]
+        scala: [2.12.13, 2.13.4]
 
     steps:
     - uses: actions/checkout@v1
@@ -28,15 +28,9 @@ jobs:
       shell: bash
       run: |
         set -e
+        ./ci_setup.sh
         sbt ++${{matrix.scala}} test
         sbt scalafmtCheck test:scalafmtCheck scalafmtSbtCheck
-    - name: Test native
-      if: ${{matrix.scala == '2.11.7' }}
-      shell: bash
-      run: |
-        set -e
-        ./ci_setup.sh
-        sbt protobufRuntimeScalaNative/test
 
   # Single final job for mergify.
   ci-passed:

--- a/build.sbt
+++ b/build.sbt
@@ -34,6 +34,7 @@ releaseProcess := Seq[ReleaseStep](
   setReleaseVersion,
   commitReleaseVersion,
   tagRelease,
+  releaseStepCommandAndRemaining("+publishSigned;"),
   releaseStepCommand("sonatypeBundleRelease"),
   setNextVersion,
   commitNextVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -94,6 +94,6 @@ lazy val protobufRuntimeScala =
 
 testFrameworks in ThisBuild += new TestFramework("utest.runner.Framework")
 
-lazy val runtimeJS     = protobufRuntimeScala.js
-lazy val runtimeJVM    = protobufRuntimeScala.jvm
+lazy val runtimeJS = protobufRuntimeScala.js
+lazy val runtimeJVM = protobufRuntimeScala.jvm
 lazy val runtimeNative = protobufRuntimeScala.native

--- a/build.sbt
+++ b/build.sbt
@@ -1,13 +1,13 @@
 import ReleaseTransformations._
 import sbtcrossproject.CrossPlugin.autoImport.crossProject
 
-val Scala211 = "2.11.12"
+val Scala212 = "2.12.13"
 
-val Scala212 = "2.12.10"
-
-val Scala213 = "2.13.1"
+val Scala213 = "2.13.4"
 
 scalaVersion in ThisBuild := Scala212
+
+crossScalaVersions in ThisBuild := Seq(Scala212, Scala213)
 
 organization in ThisBuild := "com.thesamet.scalapb"
 
@@ -34,9 +34,6 @@ releaseProcess := Seq[ReleaseStep](
   setReleaseVersion,
   commitReleaseVersion,
   tagRelease,
-  releaseStepCommandAndRemaining(
-    s"+publishSigned;++${Scala211};protobufRuntimeScalaNative/publishSigned"
-  ),
   releaseStepCommand("sonatypeBundleRelease"),
   setNextVersion,
   commitNextVersion,
@@ -47,7 +44,7 @@ publishTo in ThisBuild := sonatypePublishToBundle.value
 
 lazy val root = project
   .in(file("."))
-  .aggregate(runtimeJS, runtimeJVM)
+  .aggregate(runtimeJS, runtimeJVM, runtimeNative)
   .settings(
     publish := {},
     publishLocal := {},
@@ -61,8 +58,8 @@ lazy val protobufRuntimeScala =
       name := "protobuf-runtime-scala",
       libraryDependencies ++= {
         Seq(
-          "com.lihaoyi" %%% "utest" % "0.7.5" % "test"
-        ),
+          "com.lihaoyi" %%% "utest" % "0.7.7" % "test"
+        )
       },
       unmanagedSourceDirectories in Compile += {
         val base =
@@ -77,11 +74,9 @@ lazy val protobufRuntimeScala =
     )
     .jvmSettings(
       // Add JVM-specific settings here
-      crossScalaVersions in ThisBuild := Seq(Scala212, Scala213)
     )
     .jsSettings(
       // Add JS-specific settings here
-      crossScalaVersions in ThisBuild := Seq(Scala212, Scala213),
       scalacOptions += {
         val a = (baseDirectory in LocalRootProject).value.toURI.toString
         val g =
@@ -93,12 +88,11 @@ lazy val protobufRuntimeScala =
       }
     )
     .nativeSettings(
-      scalaVersion := Scala211,
       nativeLinkStubs := true // for utest
     )
 
 testFrameworks in ThisBuild += new TestFramework("utest.runner.Framework")
 
-lazy val runtimeJS = protobufRuntimeScala.js
-lazy val runtimeJVM = protobufRuntimeScala.jvm
+lazy val runtimeJS     = protobufRuntimeScala.js
+lazy val runtimeJVM    = protobufRuntimeScala.jvm
 lazy val runtimeNative = protobufRuntimeScala.native

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.3.1")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.4.0")
 addSbtPlugin("org.portable-scala" % "sbt-crossproject" % "1.0.0")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.0.0")
 addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.0.0")
-addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.3.9")
+addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.4.0")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")


### PR DESCRIPTION
This PR adds support for Scala Native 0.4.0 and Scala.Js 1.4.0. 
uTest version was updated to 0.7.7, was needed for Scala Native. It was published using Scala.js 1.4.0, that's why we also needed to bump up its version used. 
Used scala versions were updated to 2.12.13 and 2.13.4 to allow usage of Scala Native
Support for 2.11 was dropped, since it was used only for Scala Native
Added common list of crossVersions used in project
Update releaseProcess task - removed publishing SN 2_11, now it's part of normal release step
Change CI steps, merged Native tests with tests for other platforms