### PR TITLE
fix CodedInputStream

### DIFF
--- a/shared/src/main/scala/com/google/protobuf/CodedInputStream.scala
+++ b/shared/src/main/scala/com/google/protobuf/CodedInputStream.scala
@@ -141,8 +141,9 @@ class CodedInputStream private (buffer: Array[Byte], input: InputStream) {
         s"refillBuffer() called when $n bytes were already available in buffer"
       )
     }
-    if (totalBytesRetired + bufferPos + n > currentLimit) false
-    else if (input != null) {
+    if (totalBytesRetired + bufferPos + n > currentLimit) {
+      return false
+    } else if (input != null) {
       val pos: Int = bufferPos
       if (pos > 0) {
         if (bufferSize > pos) {


### PR DESCRIPTION
https://github.com/protocolbuffers/protobuf/blob/d617c032217d017ad10119e17ee533c15b8a27d9/java/core/src/main/java/com/google/protobuf/CodedInputStream.java#L2775C1-L2778

```
[warn] -- [E129] Potential Issue Warning: /home/runner/work/protobuf-scala-runtime/protobuf-scala-runtime/shared/src/main/scala/com/google/protobuf/CodedInputStream.scala:144:58 
[warn] 144 |    if (totalBytesRetired + bufferPos + n > currentLimit) false
[warn]     |                                                          ^^^^^
[warn]     |A pure expression does nothing in statement position; you may be omitting necessary parentheses
[warn]     |
[warn]     | longer explanation available when compiling with `-explain`
```