### PR TITLE
fix scalacOptions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,8 +9,16 @@ ThisBuild / crossScalaVersions := Seq(Scala212, Scala213, Scala3)
 
 ThisBuild / organization := "com.thesamet.scalapb"
 
+ThisBuild / scalacOptions ++= {
+  if (scalaBinaryVersion.value == "2.12") {
+    Seq("-Xfuture")
+  } else {
+    Nil
+  }
+}
+
 ThisBuild / scalacOptions ++= Seq(
-  "-Xfuture"
+  "-deprecation"
 )
 
 ThisBuild / publishTo := sonatypePublishToBundle.value


### PR DESCRIPTION
- add `-deprecation`
- remove `-Xfuture` if Scala 2.13 or 3


Scala 3

```
[warn] bad option '-Xfuture' was ignored
```


Scala 2.13

```
[warn] -Xfuture is deprecated: Not used since 2.13.
```