### PR TITLE
fix warning

### DIFF
--- a/shared/src/main/scala-2.13+/com/google/protobuf/ByteStringCompanionParent.scala
+++ b/shared/src/main/scala-2.13+/com/google/protobuf/ByteStringCompanionParent.scala
@@ -8,7 +8,7 @@ abstract class ByteStringCompanionParent
   override def fromSpecific(it: IterableOnce[Byte]): ByteString = {
     val builder = newBuilder
     builder ++= it
-    builder.result
+    builder.result()
   }
 
 }


### PR DESCRIPTION
 Scala 2.13 with `-deprecation`

```
[warn] my-protobuf-scala-runtime-project-path/shared/src/main/scala-2.13+/com/google/protobuf/ByteStringCompanionParent.scala:11:13: Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method result,
[warn] or remove the empty argument list from its definition (Java-defined methods are exempt).
[warn] In Scala 3, an unapplied method like this will be eta-expanded into a function. [quickfixable]
[warn]     builder.result
[warn]             ^
```