### PR TITLE
Add getLastTag to CodedInputStream

### DIFF
--- a/shared/src/main/scala/com/google/protobuf/CodedInputStream.scala
+++ b/shared/src/main/scala/com/google/protobuf/CodedInputStream.scala
@@ -462,6 +462,10 @@ class CodedInputStream private (buffer: Array[Byte], input: InputStream) {
     }
   }
 
+  def getLastTag(): Int = {
+    lastTag
+  }
+
   def getBytesUntilLimit: Int = {
     if (currentLimit == Integer.MAX_VALUE) {
       return -1


### PR DESCRIPTION
This method exists in the Java implementation https://github.com/protocolbuffers/protobuf/blob/f105753bd8e1eef1426f1c58574ffeadcae04b00/java/core/src/main/java/com/google/protobuf/CodedInputStream.java#L214 and I was trying to cross-compile some code that uses it 😄 

By the way I notice the CI publish is broken, I guess the project needs to be migrated to Sonatype Central? (hoping I can use a snapshot with this fix, or even better a release 🙏 )